### PR TITLE
ramips: fix leds for TP-Link Archer C20 v4

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -329,7 +329,6 @@ tplink,c20-v1)
 tplink,c20-v4)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
-	ucidef_set_led_netdev "wlan2g" "wlan2g" "$boardname:green:wlan2g" "wlan0"
 	;;
 tplink,c50-v3|\
 tplink,c50-v4)

--- a/target/linux/ramips/dts/ArcherC20v4.dts
+++ b/target/linux/ramips/dts/ArcherC20v4.dts
@@ -42,11 +42,13 @@
 		wlan5g {
 			label = "c20-v4:green:wlan5g";
 			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan2g {
 			label = "c20-v4:green:wlan2g";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps {
@@ -84,7 +86,7 @@
 &pinctrl {
 	state_default: pinctrl0 {
 		gpio {
-			ralink,group = "i2s", "refclk", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an", "wdt";
+			ralink,group = "i2s", "gpio", "refclk", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an", "wdt";
 			ralink,function = "gpio";
 		};
 	};


### PR DESCRIPTION
- add "gpio" group for wan_orange led
- use tpt triggers for wifi led indication
- add wifi 5 GHz led support

Signed-off-by: Maxim Anisimov <maxim.anisimov.ua@gmail.com>
[slight commit message adjustment, backport]
Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
(cherry picked from commit 3a538db60abfc50b47ce1774f66d489700a50c00)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
